### PR TITLE
Fix #64 - build fails in license-tool-plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -343,6 +343,9 @@
 				<groupId>org.eclipse.dash</groupId>
 				<artifactId>license-tool-plugin</artifactId>
 				<version>1.0.2</version>
+				<configuration>
+					<licenses>https://www.eclipse.org/legal/licenses/licenses.json</licenses>
+				</configuration>
 				<executions>
 					<execution>
 						<id>license-check</id>


### PR DESCRIPTION
Explicitly provide the approved licenses URL, as the dash plugin failed to follow a redirect and failed the build.