### PR TITLE
Fix #64 - bump licence-tool-plugin version to 1.1.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -342,10 +342,7 @@
 			<plugin>
 				<groupId>org.eclipse.dash</groupId>
 				<artifactId>license-tool-plugin</artifactId>
-				<version>1.0.2</version>
-				<configuration>
-					<licenses>https://www.eclipse.org/legal/licenses/licenses.json</licenses>
-				</configuration>
+				<version>1.1.0</version>
 				<executions>
 					<execution>
 						<id>license-check</id>


### PR DESCRIPTION
The 1.1.0 version of the licence-tool-plugin works fine with the redirected approved licenses default URL