### PR TITLE
Fix #77: Prepare for open source DTFJ plugin

### DIFF
--- a/plugins/org.eclipse.mat.chart/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.chart/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.mat.report;bundle-version="1.2.0",
  org.eclipse.emf.ecore
 Export-Package: org.eclipse.mat.impl.chart;x-friends:="org.eclipse.mat.chart.ui"
 Import-Package: org.eclipse.core.runtime
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.mat.dtfj/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.dtfj/META-INF/MANIFEST.MF
@@ -4,16 +4,16 @@ Bundle-SymbolicName: org.eclipse.mat.dtfj;singleton:=true
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Version: 1.16.0.qualifier
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.mat.parser;bundle-version="1.0.0",
  org.eclipse.core.runtime;bundle-version="3.4",
  org.eclipse.core.commands;bundle-version="3.3.100"
 Bundle-Activator: org.eclipse.mat.dtfj.InitDTFJ
 Bundle-ActivationPolicy: lazy
 Eclipse-LazyStart: true
-Import-Package: com.ibm.dtfj.image;bundle-symbolic-name="com.ibm.dtfj.api";bundle-version="[1.3,2.0)";resolution:=optional,
- com.ibm.dtfj.java;bundle-symbolic-name="com.ibm.dtfj.api";bundle-version="[1.3,2.0)";resolution:=optional,
- com.ibm.dtfj.runtime;bundle-symbolic-name="com.ibm.dtfj.api";bundle-version="[1.3,2.0)";resolution:=optional,
+Import-Package: com.ibm.dtfj.image;bundle-symbolic-name="com.ibm.dtfj.api";resolution:=optional,
+ com.ibm.dtfj.java;bundle-symbolic-name="com.ibm.dtfj.api";resolution:=optional,
+ com.ibm.dtfj.runtime;bundle-symbolic-name="com.ibm.dtfj.api";resolution:=optional,
  com.ibm.icu.text,
  org.eclipse.jface.dialogs;resolution:=optional,
  org.eclipse.jface.preference;resolution:=optional,

--- a/plugins/org.eclipse.mat.dtfj/src/org/eclipse/mat/dtfj/DTFJIndexBuilder.java
+++ b/plugins/org.eclipse.mat.dtfj/src/org/eclipse/mat/dtfj/DTFJIndexBuilder.java
@@ -2907,14 +2907,14 @@ public class DTFJIndexBuilder implements IIndexBuilder
         {
             // Use reflection so we don't have to link to com.ibm.dtfj.j9
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            PrintStream ps = new PrintStream(baos, true, StandardCharsets.UTF_8);
+            PrintStream ps = new PrintStream(baos, true, StandardCharsets.UTF_8.name());
             Class<?> ddrInteractive = dtfjInfo.getImage().getClass().getClassLoader().loadClass("com.ibm.j9ddr.tools.ddrinteractive.DDRInteractive"); //$NON-NLS-1$
             Constructor<?>cns = ddrInteractive.getConstructor(Object.class, ps.getClass());
             Object jdmpview = cns.newInstance(dtfjInfo.getImage(), ps);
             Method m = ddrInteractive.getMethod("processLine", String.class); //$NON-NLS-1$
             m.invoke(jdmpview, command);
             ps.close();
-            return baos.toString(StandardCharsets.UTF_8);
+            return baos.toString(StandardCharsets.UTF_8.name());
         }
         catch (Exception e)
         {

--- a/plugins/org.eclipse.mat.ibmdumps/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.ibmdumps/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 1.16.0.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4",
  org.eclipse.mat.api;bundle-version="1.0.0",
  org.eclipse.mat.report;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.mat.jdt/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.jdt/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.jdt;singleton:=true
 Bundle-Version: 1.16.0.qualifier
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.mat.api;bundle-version="1.0.0",
  org.eclipse.core.runtime,
  org.eclipse.core.jobs,

--- a/plugins/org.eclipse.mat.jruby.resolver/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.jruby.resolver/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.jruby.resolver;singleton:=true
 Bundle-Version: 1.16.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.mat.api;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.core.runtime
 Export-Package: org.eclipse.mat.jruby.resolver

--- a/plugins/org.eclipse.mat.ui.capabilities/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.ui.capabilities/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.mat.ui.capabilities;singleton:=true
 Bundle-Version: 1.16.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="3.4.0"
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: plugin
 Bundle-Copyright: Copyright (c) 2010, 2022 SAP AG. 
  All rights reserved. This program and the accompanying materials 

--- a/plugins/org.eclipse.mat.ui.rcp.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.ui.rcp.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Memory Analyzer Tests
 Bundle-SymbolicName: org.eclipse.mat.ui.rcp.tests;singleton:=true
 Bundle-Version: 1.16.0.qualifier
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Import-Package: junit.framework;version="4.3.1",
  org.eclipse.swt,

--- a/plugins/org.eclipse.mat.ui.rcp/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.ui.rcp/META-INF/MANIFEST.MF
@@ -37,7 +37,7 @@ Import-Package: org.eclipse.core.commands.common,
  org.eclipse.ui.views
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Activator: org.eclipse.mat.ui.rcp.RCPPlugin
 Bundle-Localization: plugin
 Bundle-Copyright: Copyright (c) 2008, 2022 SAP AG and IBM Corporation. 


### PR DESCRIPTION
* Remove the version constraint on the plugin to allow newer versions
* Upgrade Java 5 references to Java 8
* Remove some unnecessary > Java 8 API usage