### PR TITLE
[MAT 1.16.0 Release, #81] Update copyright headers

### DIFF
--- a/features/org.eclipse.mat.chart.feature/feature.properties
+++ b/features/org.eclipse.mat.chart.feature/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2009, 2023 SAP AG, IBM Corporation and others.
+# Copyright (c) 2009, 2024 SAP AG, IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ updateSiteName=Memory Analyzer Update Site
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=\
-Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.\n\
+Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.\n\
 \n\
 Visit https://eclipse.dev/mat/
 ################ end of copyright property ####################################

--- a/features/org.eclipse.mat.feature/feature.properties
+++ b/features/org.eclipse.mat.feature/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.
+# Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -34,7 +34,7 @@ IBMDTFJSiteName=IBM Diagnostic Tool Framework for Java for reading snapshots fro
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=\
-Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.\n\
+Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.\n\
 \n\
 Visit https://eclipse.dev/mat/
 ################ end of copyright property ####################################

--- a/features/org.eclipse.mat.ui.rcp.feature/feature.properties
+++ b/features/org.eclipse.mat.ui.rcp.feature/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.
+# Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ updateSiteName=Memory Analyzer Update Site
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=\
-Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.\n\
+Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.\n\
 \n\
 Visit https://eclipse.dev/mat/
 ################ end of copyright property ####################################

--- a/org.eclipse.mat.product/mat.product
+++ b/org.eclipse.mat.product/mat.product
@@ -10,7 +10,7 @@
 
 Version: 1.16.0
 
-Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.
+Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
 
 Visit https://eclipse.dev/mat/
       </text>
@@ -191,7 +191,7 @@ United States, other countries, or both.
    </license>
 
    <copyright>
-Copyright (c) 2008, 2022 SAP AG, IBM Corporation and others.
+Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which is available at

--- a/org.eclipse.mat.product/pom.xml
+++ b/org.eclipse.mat.product/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-    Copyright (c) 2010, 2023 SAP AG.
+    Copyright (c) 2010, 2024 SAP AG.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2009, 2023 SAP AG and others
+    Copyright (c) 2009, 2024 SAP AG and others
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/plugins/org.eclipse.mat.api/about.properties
+++ b/plugins/org.eclipse.mat.api/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010, 2023 SAP AG.
+# Copyright (c) 2010, 2024 SAP AG.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -15,6 +15,6 @@ blurb=Eclipse Memory Analyzer - API feature\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.\n\
+Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.\n\
 \n\
 Visit https://eclipse.dev/mat/

--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadDetailsResolver.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadDetailsResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *    Andrew Johnson (IBM Corporation) - initial API and implementation
+ *    Jason Koch (Netflix, Inc) - Lazily load ThreadInfo information
  *******************************************************************************/
 package org.eclipse.mat.inspections.threads;
 

--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadInfoImpl.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SAP AG & IBM Corporation.
+ * Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  * Contributors:
  *    SAP AG - initial API and implementation
  *    IBM Corporation - optional columns
+ *    Jason Koch (Netflix, Inc) - Lazily load ThreadInfo information
  *******************************************************************************/
 package org.eclipse.mat.inspections.threads;
 

--- a/plugins/org.eclipse.mat.chart/about.properties
+++ b/plugins/org.eclipse.mat.chart/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010, 2023 SAP AG.
+# Copyright (c) 2010, 2024 SAP AG.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -15,6 +15,6 @@ blurb=Eclipse Memory Analyzer - Chart feature\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.\n\
+Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.\n\
 \n\
 Visit https://eclipse.dev/mat/

--- a/plugins/org.eclipse.mat.dtfj/src/org/eclipse/mat/dtfj/DTFJIndexBuilder.java
+++ b/plugins/org.eclipse.mat.dtfj/src/org/eclipse/mat/dtfj/DTFJIndexBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009,2023 IBM Corporation.
+ * Copyright (c) 2009,2024 IBM Corporation.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/plugins/org.eclipse.mat.dtfj/src/org/eclipse/mat/dtfj/Messages.java
+++ b/plugins/org.eclipse.mat.dtfj/src/org/eclipse/mat/dtfj/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009,2022 IBM Corporation.
+ * Copyright (c) 2009,2024 IBM Corporation.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/index/IndexReader.java
+++ b/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/index/IndexReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 SAP AG, IBM Corporation and others.
+ * Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  * Contributors:
  *    SAP AG - initial API and implementation
  *    Andrew Johnson - enhancements for huge dumps
+ *    Jason Koch (Netflix, Inc) - enhancements IO on slower devices
  *******************************************************************************/
 package org.eclipse.mat.parser.index;
 

--- a/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/index/IndexWriter.java
+++ b/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/index/IndexWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.
+ * Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/internal/Messages.java
+++ b/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/internal/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2023 SAP AG and IBM Corporation.
+ * Copyright (c) 2009, 2024 SAP AG, IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  * Contributors:
  *    SAP AG - initial API and implementation
  *    IBM Corporation - validation of indices
+ *    Jason Koch - performance enhancements
  *******************************************************************************/
 package org.eclipse.mat.parser.internal;
 

--- a/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/internal/SnapshotImpl.java
+++ b/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/internal/SnapshotImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.
+ * Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  * Contributors:
  *    SAP AG - initial API and implementation
  *    IBM Corporation - validation of indices
+ *    Jason Koch - performance enhancements
  *******************************************************************************/
 package org.eclipse.mat.parser.internal;
 

--- a/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/internal/snapshot/MultiplePathsFromGCRootsComputerImpl.java
+++ b/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/internal/snapshot/MultiplePathsFromGCRootsComputerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SAP AG and IBM Corporation.
+ * Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,8 @@
  *
  * Contributors:
  *    SAP AG - initial API and implementation
- *     Andrew Johnson (IBM Corporation) - performance improvements
+ *    Andrew Johnson (IBM Corporation) - performance improvements
+ *    Jason Koch (Netflix, Inc) - performance improvements
  *******************************************************************************/
 package org.eclipse.mat.parser.internal.snapshot;
 

--- a/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/internal/snapshot/ObjectMarker.java
+++ b/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/internal/snapshot/ObjectMarker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SAP AG and IBM Corporation.
+ * Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/io/SimpleBufferedRandomAccessInputStream.java
+++ b/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/io/SimpleBufferedRandomAccessInputStream.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2010 SAP AG.
+ * Copyright (c) 2008, 2024 SAP AG and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *    SAP AG - initial API and implementation
+ *    Jason Koch (Netflix, Inc) - IO enhancements on slower devices 
  *******************************************************************************/
 package org.eclipse.mat.parser.io;
 

--- a/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/model/ClassImpl.java
+++ b/plugins/org.eclipse.mat.parser/src/org/eclipse/mat/parser/model/ClassImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 SAP AG, IBM Corporation and others.
+ * Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/TestSnapshots.java
+++ b/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/TestSnapshots.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SAP AG and IBM Corporation.
+ * Copyright (c) 2008, 2024 SAP AG and IBM Corporation.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/collect/ExtractCollectionEntriesTest.java
+++ b/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/collect/ExtractCollectionEntriesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 SAP AG and IBM Corporation
+ * Copyright (c) 2010, 2024 SAP AG and IBM Corporation
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/snapshot/GeneralSnapshotTests.java
+++ b/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/snapshot/GeneralSnapshotTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010,2023 IBM Corporation.
+ * Copyright (c) 2010,2024 IBM Corporation.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/snapshot/OQLTest.java
+++ b/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/snapshot/OQLTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 SAP AG and IBM Corporation.
+ * Copyright (c) 2008, 2024 SAP AG and IBM Corporation.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/plugins/org.eclipse.mat.ui.help/legal.dita
+++ b/plugins/org.eclipse.mat.ui.help/legal.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2008, 2023 SAP AG.
+    Copyright (c) 2008, 2024 SAP AG.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@
 		<copyright>
 			<copyryear year=""></copyryear>
 			<copyrholder>
-				Copyright (c) 2008, 2023 SAP AG and others.
+				Copyright (c) 2008, 2024 SAP AG and others.
 			    All rights reserved. This program and the accompanying materials
 			    are made available under the terms of the Eclipse Public License 2.0
 			    which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@
 		<section>
 			<title>Notices</title>
 			<p>
-				The material in this guide is Copyright (c) SAP AG and IBM Corporation 2008, 2023
+				The material in this guide is Copyright (c) SAP AG and IBM Corporation 2008, 2024
 			</p>
 			<p>
 				<xref format="html" href="about.html">Terms and conditions regarding the use of this guide.</xref> 

--- a/plugins/org.eclipse.mat.ui.help/legal.html
+++ b/plugins/org.eclipse.mat.ui.help/legal.html
@@ -6,8 +6,8 @@
 
 <meta name="generator" content="DITA-OT" /><meta name="DC.type" content="reference" />
 <meta name="DC.title" content="Legal" />
-<meta name="copyright" content="Copyright (c) 2008, 2023 SAP AG and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/ " type="primary" />
-<meta name="DC.rights.owner" content="Copyright (c) 2008, 2023 SAP AG and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/ " type="primary" />
+<meta name="copyright" content="Copyright (c) 2008, 2024 SAP AG and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/ " type="primary" />
+<meta name="DC.rights.owner" content="Copyright (c) 2008, 2024 SAP AG and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/ " type="primary" />
 <meta name="DC.format" content="XHTML" />
 <meta name="DC.identifier" content="ref_noteworthy" />
 <meta name="DC.language" content="en-us" />
@@ -25,7 +25,7 @@
 		<div class="section"><h2 class="title sectiontitle">Notices</h2>
 			
 			<p class="p">
-				The material in this guide is Copyright (c) SAP AG and IBM Corporation 2008, 2023
+				The material in this guide is Copyright (c) SAP AG and IBM Corporation 2008, 2024
 			</p>
 
 			<p class="p">

--- a/plugins/org.eclipse.mat.ui.help/reference/inspections/copy.html
+++ b/plugins/org.eclipse.mat.ui.help/reference/inspections/copy.html
@@ -36,24 +36,24 @@
 		<div class="section"><h2 class="title sectiontitle">Commands</h2>
 			
 			<table cellpadding="4" cellspacing="0" summary="" border="1" class="simpletable"><col style="width:50%" /><col style="width:50%" /><thead><tr class="sthead">
-					<th style="vertical-align:bottom;text-align:left;" id="d302e44" class="stentry">Command</th>
+					<th style="vertical-align:bottom;text-align:left;" id="d305e44" class="stentry">Command</th>
 
-					<th style="vertical-align:bottom;text-align:left;" id="d302e47" class="stentry">Description</th>
+					<th style="vertical-align:bottom;text-align:left;" id="d305e47" class="stentry">Description</th>
 
 				</tr>
 </thead><tbody><tr id="ref_inspections_copy__address" class="strow">
-					<td style="vertical-align:top;" headers="d302e44" class="stentry">Copy Address</td>
+					<td style="vertical-align:top;" headers="d305e44" class="stentry">Copy Address</td>
 
-					<td style="vertical-align:top;" headers="d302e47" class="stentry">
+					<td style="vertical-align:top;" headers="d305e47" class="stentry">
 					Copies the address of an object, as a hexadecimal number with a 0x prefix to the clipboard.
 					If there are multiple objects, they are on separate lines.
 					</td>
 
 				</tr>
 <tr id="ref_inspections_copy__fqclassname" class="strow">
-					<td style="vertical-align:top;" headers="d302e44" class="stentry">Copy Class Name</td>
+					<td style="vertical-align:top;" headers="d305e44" class="stentry">Copy Class Name</td>
 
-					<td style="vertical-align:top;" headers="d302e47" class="stentry">
+					<td style="vertical-align:top;" headers="d305e47" class="stentry">
 					Copies the class name of an object to the clipboard.
 					If there are multiple objects, then the class names are on separate lines.
 					If some of the objects are of the same class, duplicate class names will appear in the clipboard.
@@ -62,9 +62,9 @@
 
 				</tr>
 <tr id="ref_inspections_copy__value" class="strow">
-					<td style="vertical-align:top;" headers="d302e44" class="stentry">Copy Value</td>
+					<td style="vertical-align:top;" headers="d305e44" class="stentry">Copy Value</td>
 
-					<td style="vertical-align:top;" headers="d302e47" class="stentry">
+					<td style="vertical-align:top;" headers="d305e47" class="stentry">
 					Copies the value that Eclipse Memory Analyzer displays for the object.
 					For example, the string contents for a java.lang.String, the integer valeu as a decimal
 					for an Integer.
@@ -74,9 +74,9 @@
 
 				</tr>
 <tr id="ref_inspections_copy__copyoql" class="strow">
-					<td style="vertical-align:top;" headers="d302e44" class="stentry">Copy OQL Query</td>
+					<td style="vertical-align:top;" headers="d305e44" class="stentry">Copy OQL Query</td>
 
-					<td style="vertical-align:top;" headers="d302e47" class="stentry">
+					<td style="vertical-align:top;" headers="d305e47" class="stentry">
 					Copies an OQL query representing all the selected objects to the clipboard.
 					If there are a large number of objects and they are not all the instances of a class or
 					something else which can be represented succinctly in OQL then the copy might fail with an
@@ -85,9 +85,9 @@
 
 				</tr>
 <tr id="ref_inspections_copy__savevalueas" class="strow">
-					<td style="vertical-align:top;" headers="d302e44" class="stentry">Save Value to File</td>
+					<td style="vertical-align:top;" headers="d305e44" class="stentry">Save Value to File</td>
 
-					<td style="vertical-align:top;" headers="d302e47" class="stentry">
+					<td style="vertical-align:top;" headers="d305e47" class="stentry">
 					Save to a file the value of char[], String, StringBuffer or StringBuilder into a text file,
 					or for a single primitive array store the elements as binary, or for other types,
 					the printable value or the class name and address.
@@ -95,9 +95,9 @@
 
 				</tr>
 <tr id="ref_inspections_copy__selection" class="strow">
-					<td style="vertical-align:top;" headers="d302e44" class="stentry">Copy Selection</td>
+					<td style="vertical-align:top;" headers="d305e44" class="stentry">Copy Selection</td>
 
-					<td style="vertical-align:top;" headers="d302e47" class="stentry">
+					<td style="vertical-align:top;" headers="d305e47" class="stentry">
 					Copies a text representation of the selected rows of the tree or table, together with the heading.
 					</td>
 

--- a/plugins/org.eclipse.mat.ui.rcp/about.properties
+++ b/plugins/org.eclipse.mat.ui.rcp/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010, 2023 SAP AG.
+# Copyright (c) 2010, 2024 SAP AG.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -15,6 +15,6 @@ blurb=Eclipse Memory Analyzer - RCP feature\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.\n\
+Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.\n\
 \n\
 Visit http://eclipse.dev/mat/

--- a/plugins/org.eclipse.mat.ui.rcp/plugin.properties
+++ b/plugins/org.eclipse.mat.ui.rcp/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2008, 2023 SAP AG.
+# Copyright (c) 2008, 2024 SAP AG.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,9 +16,9 @@ Bundle-Name = Memory Analyzer - Rich Client Platform
 activity.description.Menus_which_should_not_shown = Menus which should not be shown inside the Memory Analyzer RCP
 activity.name.Memory_Analyzer_don_t_enable = Memory Analyzer (don't enable)
 product.appName = Eclipse Memory Analyzer
-product.aboutText = Eclipse Memory Analyzer Version {1}\n\n\Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.\n\n\Visit https://eclipse.dev/mat/
+product.aboutText = Eclipse Memory Analyzer Version {1}\n\n\Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.\n\n\Visit https://eclipse.dev/mat/
 copyright=\
-Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.\n\
+Copyright (c) 2008, 2024 SAP AG, IBM Corporation and others.\n\
 \n\
 Visit https://eclipse.dev/mat/
 ################ end of copyright property ####################################


### PR DESCRIPTION
- updated copyright headers in several source files which were changes last year
- updated the copyright message on visible places - Eclipse about, feature's about, etc...