### PR TITLE
[Fixes for #95] Adjust memory settings for the tests

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -65,6 +65,7 @@
 		<!-- mat-release-repo-url specifies from which p2 repo the MAT bundles 
 			come, when the build-release profile is used -->
 		<mat-release-repo-url>http://download.eclipse.org/mat/latest/update-site/</mat-release-repo-url>
+		<mat-tests-parameters>-Xmx1024m</mat-tests-parameters>
 		<p2.mirrorsPrefix>/mat/1.16.1/update-site/</p2.mirrorsPrefix>
 		<p2.statsURI>https://download.eclipse.org/stats/mat</p2.statsURI>
 		<p2.mirrorsURL>https://www.eclipse.org/downloads/download.php?format=xml&amp;file=${p2.mirrorsPrefix}</p2.mirrorsURL>
@@ -406,7 +407,7 @@
 					<artifactId>tycho-surefire-plugin</artifactId>
 					<version>${tycho-version}</version>
 					<configuration>
-						<argLine>-ea -Xmx1536m --add-exports=java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED</argLine>
+						<argLine>-ea ${mat-tests-parameters} --add-exports=java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED</argLine>
 						<!--  debugging OOM on CI - make the temp files appear in the workspace -->
 						<!--  <argLine>-ea -Xmx1024m -Djava.io.tmpdir=. -XX:+HeapDumpOnOutOfMemoryError</argLine>-->
 						<!-- <testFailureIgnore>true</testFailureIgnore> -->


### PR DESCRIPTION
- reduce the default value to -Xmx1024m
- make the value configurable, so that it could be overwritten in the CI jobs