### PR TITLE
[Fix #107] Add log.index file and bump MAT to 1.17.0 because of new APIs

### DIFF
--- a/features/org.eclipse.mat.chart.feature/feature.xml
+++ b/features/org.eclipse.mat.chart.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.mat.chart.feature"
       label="%featureName"
-      version="1.16.1.qualifier"
+      version="1.17.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.mat.chart">
 
@@ -42,8 +42,8 @@
       <import plugin="org.eclipse.birt.chart.device.swt" version="2.3.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.birt.chart.engine.extension" version="2.3.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.birt.core" version="2.3.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.mat.ui" version="1.16.1" match="greaterOrEqual"/>
-      <import feature="org.eclipse.mat.feature" version="1.16.1" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.mat.ui" version="1.17.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.mat.feature" version="1.17.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/features/org.eclipse.mat.chart.feature/pom.xml
+++ b/features/org.eclipse.mat.chart.feature/pom.xml
@@ -20,7 +20,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.chart.feature</artifactId>

--- a/features/org.eclipse.mat.feature/about.mappings
+++ b/features/org.eclipse.mat.feature/about.mappings
@@ -11,4 +11,4 @@
 #    IBM Corporation - initial API and implementation and/or initial documentation
 ###############################################################################
 #Build
-0=1.16.1
+0=1.17.0

--- a/features/org.eclipse.mat.feature/feature.xml
+++ b/features/org.eclipse.mat.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.mat.feature"
       label="%featureName"
-      version="1.16.1.qualifier"
+      version="1.17.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.mat.api">
    <install-handler/>

--- a/features/org.eclipse.mat.feature/pom.xml
+++ b/features/org.eclipse.mat.feature/pom.xml
@@ -20,7 +20,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.feature</artifactId>

--- a/features/org.eclipse.mat.ui.rcp.feature/feature.xml
+++ b/features/org.eclipse.mat.ui.rcp.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.mat.ui.rcp.feature"
       label="%featureName"
-      version="1.16.1.qualifier"
+      version="1.17.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.mat.ui.rcp">
 

--- a/features/org.eclipse.mat.ui.rcp.feature/pom.xml
+++ b/features/org.eclipse.mat.ui.rcp.feature/pom.xml
@@ -20,7 +20,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.ui.rcp.feature</artifactId>

--- a/features/org.eclipse.mat.ui.rcp.feature/rootfiles/.eclipseproduct
+++ b/features/org.eclipse.mat.ui.rcp.feature/rootfiles/.eclipseproduct
@@ -1,3 +1,3 @@
 name=Eclipse Memory Analyzer
 id=org.eclipse.mat
-version=1.16.1
+version=1.17.0

--- a/org.eclipse.mat.product/mat.product
+++ b/org.eclipse.mat.product/mat.product
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Memory Analyzer Tool" uid="org.eclipse.mat.ui.rcp.MemoryAnalyzer" id="org.eclipse.mat.ui.rcp.MemoryAnalyzer" application="org.eclipse.mat.ui.rcp.application" version="1.16.1.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Memory Analyzer Tool" uid="org.eclipse.mat.ui.rcp.MemoryAnalyzer" id="org.eclipse.mat.ui.rcp.MemoryAnalyzer" application="org.eclipse.mat.ui.rcp.application" version="1.17.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.mat.ui.rcp/icons/eclipse_lg.gif"/>
       <text>
          Eclipse Memory Analyzer
 
-Version: 1.16.1
+Version: 1.17.0
 
 Copyright (c) 2008, 2025 SAP AG, IBM Corporation and others.
 

--- a/org.eclipse.mat.product/pom.xml
+++ b/org.eclipse.mat.product/pom.xml
@@ -21,7 +21,7 @@
 		<groupId>org.eclipse.mat</groupId>
 		<artifactId>parent</artifactId>
 		<relativePath>../parent</relativePath>
-		<version>1.16.1-SNAPSHOT</version>
+		<version>1.17.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.mat.product</artifactId>

--- a/org.eclipse.mat.targetdef/pom.xml
+++ b/org.eclipse.mat.targetdef/pom.xml
@@ -15,7 +15,7 @@
 		<groupId>org.eclipse.mat</groupId>
 		<artifactId>parent</artifactId>
 		<relativePath>../parent</relativePath>
-		<version>1.16.1-SNAPSHOT</version>
+		<version>1.17.0-SNAPSHOT</version>
 	</parent>
 
   <artifactId>org.eclipse.mat.targetdef</artifactId>

--- a/org.eclipse.mat.updatesite/pom.xml
+++ b/org.eclipse.mat.updatesite/pom.xml
@@ -19,7 +19,7 @@
 		<groupId>org.eclipse.mat</groupId>
 		<artifactId>parent</artifactId>
 		<relativePath>../parent</relativePath>
-		<version>1.16.1-SNAPSHOT</version>
+		<version>1.17.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.mat.updatesite</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>org.eclipse.mat</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.16.1-SNAPSHOT</version>
+	<version>1.17.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>MAT Parent</name>
@@ -66,7 +66,7 @@
 			come, when the build-release profile is used -->
 		<mat-release-repo-url>http://download.eclipse.org/mat/latest/update-site/</mat-release-repo-url>
 		<mat-tests-parameters>-Xmx1024m</mat-tests-parameters>
-		<p2.mirrorsPrefix>/mat/1.16.1/update-site/</p2.mirrorsPrefix>
+		<p2.mirrorsPrefix>/mat/1.17.0/update-site/</p2.mirrorsPrefix>
 		<p2.statsURI>https://download.eclipse.org/stats/mat</p2.statsURI>
 		<p2.mirrorsURL>https://www.eclipse.org/downloads/download.php?format=xml&amp;file=${p2.mirrorsPrefix}</p2.mirrorsURL>
 		<!--  Track the branding plugin for each feature. Current doesn't work and all artifacts tracked. -->

--- a/plugins/org.eclipse.mat.api/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.api/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.mat.api;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Export-Package: org.eclipse.mat.inspections.osgi;x-friends:="org.eclipse.mat.ui",
  org.eclipse.mat.inspections.osgi.model;x-friends:="org.eclipse.mat.ui",
  org.eclipse.mat.internal.acquire;x-friends:="org.eclipse.mat.ui",

--- a/plugins/org.eclipse.mat.api/about.mappings
+++ b/plugins/org.eclipse.mat.api/about.mappings
@@ -11,4 +11,4 @@
 #     IBM Corporation - initial API and implementation and/or initial documentation
 ###############################################################################
 #Build
-0=1.16.1
+0=1.17.0

--- a/plugins/org.eclipse.mat.api/pom.xml
+++ b/plugins/org.eclipse.mat.api/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.api</artifactId>

--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/internal/MATPlugin.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/internal/MATPlugin.java
@@ -79,5 +79,4 @@ public class MATPlugin extends Plugin
     {
         log(new Status(severity, PLUGIN_ID, message));
     }
-
 }

--- a/plugins/org.eclipse.mat.chart.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.chart.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.chart.ui;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.mat.chart;bundle-version="1.0.0",
  org.eclipse.mat.ui;bundle-version="1.0.0",

--- a/plugins/org.eclipse.mat.chart.ui/pom.xml
+++ b/plugins/org.eclipse.mat.chart.ui/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.chart.ui</artifactId>

--- a/plugins/org.eclipse.mat.chart/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.chart/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.chart;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Require-Bundle: org.eclipse.mat.report;bundle-version="1.2.0",
  org.eclipse.mat.api;bundle-version="1.0.0",
  org.eclipse.birt.chart.engine;bundle-version="2.3.0",

--- a/plugins/org.eclipse.mat.chart/about.mappings
+++ b/plugins/org.eclipse.mat.chart/about.mappings
@@ -11,4 +11,4 @@
 #     IBM Corporation - initial API and implementation and/or initial documentation
 ###############################################################################
 #Build
-0=1.16.1
+0=1.17.0

--- a/plugins/org.eclipse.mat.chart/pom.xml
+++ b/plugins/org.eclipse.mat.chart/pom.xml
@@ -20,7 +20,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.chart</artifactId>

--- a/plugins/org.eclipse.mat.dtfj/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.dtfj/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.mat.dtfj;singleton:=true
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.mat.parser;bundle-version="1.0.0",
  org.eclipse.core.runtime;bundle-version="3.4",

--- a/plugins/org.eclipse.mat.dtfj/pom.xml
+++ b/plugins/org.eclipse.mat.dtfj/pom.xml
@@ -20,7 +20,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.dtfj</artifactId>

--- a/plugins/org.eclipse.mat.hprof/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.hprof/META-INF/MANIFEST.MF
@@ -2,10 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.hprof;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Require-Bundle: org.eclipse.mat.parser;bundle-version="1.16.1",
- org.eclipse.mat.report;bundle-version="1.16.1",
+Require-Bundle: org.eclipse.mat.parser;bundle-version="1.17.0",
+ org.eclipse.mat.report;bundle-version="1.17.0",
  org.eclipse.core.runtime;bundle-version="3.4",
  org.eclipse.core.commands;bundle-version="3.3.100"
 Export-Package: org.eclipse.mat.hprof.extension,

--- a/plugins/org.eclipse.mat.hprof/pom.xml
+++ b/plugins/org.eclipse.mat.hprof/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.hprof</artifactId>

--- a/plugins/org.eclipse.mat.ibmdumps/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.ibmdumps/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.mat.ibmdumps;singleton:=true
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4",
  org.eclipse.mat.api;bundle-version="1.0.0",
  org.eclipse.mat.report;bundle-version="1.0.0"

--- a/plugins/org.eclipse.mat.ibmdumps/pom.xml
+++ b/plugins/org.eclipse.mat.ibmdumps/pom.xml
@@ -20,7 +20,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.ibmdumps</artifactId>

--- a/plugins/org.eclipse.mat.jdt/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.jdt;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.mat.api;bundle-version="1.0.0",
  org.eclipse.core.runtime,

--- a/plugins/org.eclipse.mat.jdt/pom.xml
+++ b/plugins/org.eclipse.mat.jdt/pom.xml
@@ -20,7 +20,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.jdt</artifactId>

--- a/plugins/org.eclipse.mat.jruby.resolver/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.jruby.resolver/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.jruby.resolver;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.mat.api;bundle-version="[1.0.0,2.0.0)",

--- a/plugins/org.eclipse.mat.jruby.resolver/pom.xml
+++ b/plugins/org.eclipse.mat.jruby.resolver/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.jruby.resolver</artifactId>

--- a/plugins/org.eclipse.mat.parser/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.parser/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.parser;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Activator: org.eclipse.mat.parser.internal.ParserPlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.3.100",
- org.eclipse.mat.report;bundle-version="1.16.1",
+ org.eclipse.mat.report;bundle-version="1.17.0",
  org.eclipse.mat.api;bundle-version="1.0.0";visibility:=reexport
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.mat.parser/pom.xml
+++ b/plugins/org.eclipse.mat.parser/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.parser</artifactId>

--- a/plugins/org.eclipse.mat.report/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.report/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.mat.report;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.mat,
  org.eclipse.mat.collect,

--- a/plugins/org.eclipse.mat.report/pom.xml
+++ b/plugins/org.eclipse.mat.report/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.report</artifactId>

--- a/plugins/org.eclipse.mat.report/src/org/eclipse/mat/util/FileUtils.java
+++ b/plugins/org.eclipse.mat.report/src/org/eclipse/mat/util/FileUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 SAP AG and IBM Corporation.
+ * Copyright (c) 2008, 2025 SAP AG and IBM Corporation.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.mat.util;
 
-/**
- * File utilities for things like copying icon files.
- */
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -31,6 +31,9 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.mat.report.internal.Messages;
 import org.eclipse.mat.report.internal.ReportPlugin;
 
+/**
+ * File utilities for things like copying icon files.
+ */
 public final class FileUtils
 {
     private static DirDeleter deleterThread;
@@ -249,6 +252,36 @@ public final class FileUtils
                         copy(zipFileStream, unzippedFile);
                     }
                 }
+            }
+        }
+    }
+
+    /**
+     * Append a string to a file.
+     * 
+     * @param file
+     *            The file to append to.
+     * @param message
+     *            The string to append.
+     * @param addNewline
+     *            Whether to add a newline after the message.
+     * @throws IOException
+     *             Errors writing to the file.
+     * @since 1.17
+     */
+    public static void writeToFile(File file, String message, boolean append, boolean addNewline) throws IOException
+    {
+        try (FileWriter fw = new FileWriter(file, append);
+                        BufferedWriter bw = new BufferedWriter(fw);
+                        PrintWriter out = new PrintWriter(bw))
+        {
+            if (addNewline)
+            {
+                out.println(message);
+            }
+            else
+            {
+                out.print(message);
             }
         }
     }

--- a/plugins/org.eclipse.mat.report/src/org/eclipse/mat/util/WrappedLoggingProgressListener.java
+++ b/plugins/org.eclipse.mat.report/src/org/eclipse/mat/util/WrappedLoggingProgressListener.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.mat.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Wraps another underlying IProgressListener and also writes listener entries
+ * to a log file. This will buffer messages in memory (up to 10MB, by default)
+ * until {@link #setFile(File)} is called to set the output file.
+ * 
+ * @since 1.17
+ */
+public class WrappedLoggingProgressListener implements IProgressListener
+{
+    protected IProgressListener wrappedListener;
+    protected File file;
+    protected StringBuilder buffer = new StringBuilder();
+    protected int maxBuffer = 10 * 1024 * 1024;
+    private boolean wroteIOError = false;
+
+    public WrappedLoggingProgressListener(IProgressListener wrappedListener)
+    {
+        this.wrappedListener = wrappedListener;
+    }
+
+    public void beginTask(String name, int totalWork)
+    {
+        wrappedListener.beginTask(name, totalWork);
+    }
+
+    public void done()
+    {
+        wrappedListener.done();
+    }
+
+    public boolean isCanceled()
+    {
+        return wrappedListener.isCanceled();
+    }
+
+    public void setCanceled(boolean value)
+    {
+        wrappedListener.setCanceled(value);
+    }
+
+    public void subTask(String name)
+    {
+        wrappedListener.subTask(name);
+    }
+
+    public void worked(int work)
+    {
+        wrappedListener.worked(work);
+    }
+
+    /**
+     * Set the output file to append messages to. If the file does not exist, it
+     * will attempt to be created.
+     * 
+     * @param file
+     *            The output file to append messages to.
+     */
+    public void setFile(File file)
+    {
+        this.file = file;
+    }
+
+    public void sendUserMessage(Severity severity, String message, Throwable exception)
+    {
+        wrappedListener.sendUserMessage(severity, message, exception);
+
+        String finalMessage = "[" + DateTimeFormatter.ISO_ZONED_DATE_TIME.format(ZonedDateTime.now()) + "] ["
+                        + severity.name() + "] " + message; // $NON-NLS-1$
+                                                            // $NON-NLS-2$
+                                                            // $NON-NLS-3$
+
+        if (exception != null)
+        {
+            StringWriter sw = new StringWriter();
+            exception.printStackTrace(new PrintWriter(sw));
+            String exceptionDetails = sw.toString();
+            finalMessage += System.lineSeparator() + exceptionDetails;
+        }
+
+        // If there are continous I/O errors writing to the file, then make sure
+        // we don't buffer indefinitely
+        if (buffer.length() > maxBuffer)
+        {
+            buffer.delete(0, buffer.length() - maxBuffer);
+            buffer.insert(0, "[...] "); // $NON-NLS-1$
+        }
+
+        if (file == null)
+        {
+            buffer.append(finalMessage);
+            buffer.append(System.lineSeparator());
+        }
+        else
+        {
+            try
+            {
+                if (buffer.length() > 0)
+                {
+                    FileUtils.writeToFile(file, buffer.toString(), true, false);
+                    buffer.setLength(0);
+                }
+                FileUtils.writeToFile(file, finalMessage, true, true);
+            }
+            catch (IOException e)
+            {
+                // Could not write to the log file for some reason. If this is
+                // the first time then print it out.
+                if (!wroteIOError)
+                {
+                    e.printStackTrace();
+                    wroteIOError = true;
+                }
+
+                buffer.append(finalMessage);
+                buffer.append(System.lineSeparator());
+            }
+        }
+    }
+}

--- a/plugins/org.eclipse.mat.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.tests/META-INF/MANIFEST.MF
@@ -2,15 +2,15 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Memory Analyzer Tests
 Bundle-SymbolicName: org.eclipse.mat.tests;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.mat.api;bundle-version="1.0.0",
- org.eclipse.mat.parser;bundle-version="1.16.1",
- org.eclipse.mat.hprof;bundle-version="1.16.1",
+ org.eclipse.mat.parser;bundle-version="1.17.0",
+ org.eclipse.mat.hprof;bundle-version="1.17.0",
  org.eclipse.core.runtime;bundle-version="3.4",
  org.eclipse.core.resources;bundle-version="3.3.0",
  org.apache.ant;bundle-version="1.7.0",
- org.eclipse.mat.ui;bundle-version="1.16.1",
+ org.eclipse.mat.ui;bundle-version="1.17.0",
  org.hamcrest.core,
  org.hamcrest.library
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.mat.tests/pom.xml
+++ b/plugins/org.eclipse.mat.tests/pom.xml
@@ -19,7 +19,7 @@
 		<groupId>org.eclipse.mat</groupId>
 		<artifactId>parent</artifactId>
 		<relativePath>../../parent</relativePath>
-		<version>1.16.1-SNAPSHOT</version>
+		<version>1.17.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.mat.tests</artifactId>

--- a/plugins/org.eclipse.mat.ui.capabilities/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.ui.capabilities/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.ui.capabilities;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="3.4.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/plugins/org.eclipse.mat.ui.help/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.ui.help/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.ui.help;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.3.100",
  org.eclipse.help;bundle-version="3.3.0",

--- a/plugins/org.eclipse.mat.ui.help/pom.xml
+++ b/plugins/org.eclipse.mat.ui.help/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.ui.help</artifactId>

--- a/plugins/org.eclipse.mat.ui.rcp.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.ui.rcp.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Memory Analyzer Tests
 Bundle-SymbolicName: org.eclipse.mat.ui.rcp.tests;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Import-Package: junit.framework;version="4.3.1",

--- a/plugins/org.eclipse.mat.ui.rcp.tests/pom.xml
+++ b/plugins/org.eclipse.mat.ui.rcp.tests/pom.xml
@@ -19,7 +19,7 @@
 		<groupId>org.eclipse.mat</groupId>
 		<artifactId>parent</artifactId>
 		<relativePath>../../parent</relativePath>
-		<version>1.16.1-SNAPSHOT</version>
+		<version>1.17.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.mat.ui.rcp.tests</artifactId>

--- a/plugins/org.eclipse.mat.ui.rcp/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.ui.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.mat.ui.rcp;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.mat.ui.help;bundle-version="1.0.0",
  org.eclipse.mat.ui;bundle-version="1.0.0",

--- a/plugins/org.eclipse.mat.ui.rcp/about.mappings
+++ b/plugins/org.eclipse.mat.ui.rcp/about.mappings
@@ -11,6 +11,6 @@
 #     IBM Corporation - initial API and implementation and/or initial documentation
 ###############################################################################
 #Build
-0=1.16.1
+0=1.17.0
 #Product
-1=1.16.1
+1=1.17.0

--- a/plugins/org.eclipse.mat.ui.rcp/pom.xml
+++ b/plugins/org.eclipse.mat.ui.rcp/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.ui.rcp</artifactId>

--- a/plugins/org.eclipse.mat.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.ui/META-INF/MANIFEST.MF
@@ -3,9 +3,9 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.mat.ui;singleton:=true
-Bundle-Version: 1.16.1.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Activator: org.eclipse.mat.ui.MemoryAnalyserPlugin
-Require-Bundle: org.eclipse.mat.report;bundle-version="1.16.1",
+Require-Bundle: org.eclipse.mat.report;bundle-version="1.17.0",
  org.eclipse.mat.api;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="3.4.0",
  org.eclipse.core.resources;bundle-version="3.3.0",

--- a/plugins/org.eclipse.mat.ui/pom.xml
+++ b/plugins/org.eclipse.mat.ui/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.eclipse.mat</groupId>
     <artifactId>parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.16.1-SNAPSHOT</version>
+    <version>1.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.mat.ui</artifactId>


### PR DESCRIPTION
Create a new `WrappedLoggingProgressListener` which wraps another `IProgressListener` and passes through all method calls. In addition, for `sendUserMessage`, we either buffer the message into memory if an output file hasn't been specified yet; or, if it has, then append the message to the specified file (with the main use case being the `log.index` file for each dump) (and if it's the first call since the file has been set, then write out the buffer). Create a `WrappedLoggingProgressListener` in `SnapshotFactoryImpl.openSnapshot` and then pass down this wrapped listener into the parse/reparse. Also add a new API, `FileUtils.writeToFile`. Bump MAT to 1.17.0 because of these two new APIs.