### PR TITLE
[Fix #111] Handle java.base/../Thread virtual-thread changes

### DIFF
--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadDetailsResolver.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadDetailsResolver.java
@@ -180,8 +180,8 @@ public class ThreadDetailsResolver implements IThreadDetailsResolver
 
     public void complementShallow(IThreadInfo thread, IProgressListener listener) throws SnapshotException
     {
-        final String[] PRIORITY = new String[]{"priority", "holder.priority"}; //$NON-NLS-1$
-        final String[] THREAD_STATUS = new String[]{"threadStatus", "holder.threadStatus"}; //$NON-NLS-1$
+        final String[] PRIORITY = new String[]{"priority", "holder.priority"}; //$NON-NLS-1$ //$NON-NLS-2$
+        final String[] THREAD_STATUS = new String[]{"threadStatus", "holder.threadStatus"}; //$NON-NLS-1$ //$NON-NLS-2$
 
         // Find the thread
         // Set the column data, ignore errors

--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadDetailsResolver.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadDetailsResolver.java
@@ -149,34 +149,39 @@ public class ThreadDetailsResolver implements IThreadDetailsResolver
                         (new Column(Messages.ThreadDetailsResolver_State_value, Integer.class).noTotals().formatting(hex))};
     }
 
-    Supplier<Integer> makeIntegerFieldSupplier(IThreadInfo thread, String field) {
-        return (Supplier<Integer>) () -> {
-            try {
+    static Integer resolveThreadValue(IThreadInfo thread, String[] fields) {
+        try {
+            for (String field : fields) {
                 Object o = thread.getThreadObject().resolveValue(field);
-                return (o instanceof Integer) ? (Integer)o : null;
+                if (o != null) {
+                    return (o instanceof Integer) ? (Integer)o : null;
+                }
             }
-            catch (SnapshotException e) {
-                throw new RuntimeException(e);
-            }
+            return null;
+        }
+        catch (SnapshotException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    Supplier<Integer> makeIntegerFieldSupplier(IThreadInfo thread, String[] fields) {
+        return (Supplier<Integer>) () -> {
+            Object value = resolveThreadValue(thread, fields);
+            return (value instanceof Integer) ? ((Integer) value) : null;
         };
     }
 
-    Supplier<String> makeStringFieldSupplier(IThreadInfo thread, String field, Function<Integer, String> transform) {
+    Supplier<String> makeStringFieldSupplier(IThreadInfo thread, String[] fields, Function<Integer, String> transform) {
         return (Supplier<String>) () -> {
-            try {
-                Object o = thread.getThreadObject().resolveValue(field);
-                return (o instanceof Integer) ? transform.apply((Integer)o) : null;
-            }
-            catch (SnapshotException e) {
-                throw new RuntimeException(e);
-            }
+            Object value = resolveThreadValue(thread, fields);
+            return (value instanceof Integer) ? transform.apply((Integer) value) : null;
         };
     }
 
     public void complementShallow(IThreadInfo thread, IProgressListener listener) throws SnapshotException
     {
-        final String PRIORITY = "priority"; //$NON-NLS-1$
-        final String THREAD_STATUS = "threadStatus"; //$NON-NLS-1$
+        final String[] PRIORITY = new String[]{"priority", "holder.priority"}; //$NON-NLS-1$
+        final String[] THREAD_STATUS = new String[]{"threadStatus", "holder.threadStatus"}; //$NON-NLS-1$
 
         // Find the thread
         // Set the column data, ignore errors

--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadInfoImpl.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadInfoImpl.java
@@ -165,6 +165,10 @@ import org.eclipse.mat.util.IProgressListener;
             if (daemon == null) {
                 daemon = thread.resolveValue("isDaemon"); //$NON-NLS-1$
             }
+            // after Virtual Threads (8284161), some fields were moved into 'holder'
+            if (daemon == null) {
+                daemon = thread.resolveValue("holder.daemon"); //$NON-NLS-1$
+            }
             if (daemon != null) {
                 if (daemon instanceof Boolean) {
                     return (Boolean)daemon;


### PR DESCRIPTION
With introduction of virtual-threads into the JDK, the fields inside the Thread object were moved into a nested subclass (Thread.FieldHolder) and member (holder). For the thread inspections, we now attempt to look at both locations.

before

![image](https://github.com/user-attachments/assets/f6692cee-cc85-4962-8e67-5db5ca34019b)


after

<img width="1328" alt="image" src="https://github.com/user-attachments/assets/9dee1c22-9341-4c9f-9864-e30fb01bd8a4" />
