### PR TITLE
[Fix #129] Change defaults for paths to GC roots for exclude custom

### DIFF
--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/internal/snapshot/inspections/MultiplePath2GCRootsQuery.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/internal/snapshot/inspections/MultiplePath2GCRootsQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SAP AG, IBM Corporation and others.
+ * Copyright (c) 2008, 2025 SAP AG, IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -108,7 +108,9 @@ public class MultiplePath2GCRootsQuery implements IQuery
 
     @Argument(isMandatory = false)
     public List<String> excludes = Arrays.asList( //
-                    new String[] { "java.lang.ref.WeakReference:referent", "java.lang.ref.SoftReference:referent" }); //$NON-NLS-1$ //$NON-NLS-2$
+                    new String[] { "java.lang.ref.WeakReference:referent", "java.lang.ref.SoftReference:referent", //$NON-NLS-1$ //$NON-NLS-2$
+                                    "java.lang.ref.PhantomReference:referent", "java.lang.ref.Finalizer:unfinalized", //$NON-NLS-1$ //$NON-NLS-2$
+                                    "java.lang.Runtime:<Unfinalized>" }); //$NON-NLS-1$
 
     @Argument(isMandatory = false)
     public Grouping groupBy = Grouping.FROM_GC_ROOTS;

--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/internal/snapshot/inspections/Path2GCRootsQuery.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/internal/snapshot/inspections/Path2GCRootsQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SAP AG and others.
+ * Copyright (c) 2008, 2025 SAP AG and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -75,7 +75,9 @@ public class Path2GCRootsQuery implements IQuery
 
     @Argument(isMandatory = false)
     public List<String> excludes = Arrays.asList( //
-                    new String[] { "java.lang.ref.WeakReference:referent", "java.lang.ref.SoftReference:referent" }); //$NON-NLS-1$ //$NON-NLS-2$
+                    new String[] { "java.lang.ref.WeakReference:referent", "java.lang.ref.SoftReference:referent", //$NON-NLS-1$ //$NON-NLS-2$
+                                    "java.lang.ref.PhantomReference:referent", "java.lang.ref.Finalizer:unfinalized", //$NON-NLS-1$ //$NON-NLS-2$
+                                    "java.lang.Runtime:<Unfinalized>" }); //$NON-NLS-1$
 
     @Argument(isMandatory = false)
     public int numberOfPaths = 30;

--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/internal/snapshot/inspections/annotations.properties
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/internal/snapshot/inspections/annotations.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2008, 2011 SAP AG and IBM Corporation.
+# Copyright (c) 2008, 2025 SAP AG and IBM Corporation.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ ShowInDominatorQuery.groupBy.help = Whether to group the objects in the resultin
 Group by classloader puts the classloader object, all classes loaded by the classloader and all instances of those classes together.
 
 
-Path2GCRootsQuery.name = exclude custom field...
+Path2GCRootsQuery.name = exclude custom fields or classes...
 Path2GCRootsQuery.category = 3|Path To GC Roots
 Path2GCRootsQuery.menu.0.label = 1|with all references
 Path2GCRootsQuery.menu.1.label = 2|exclude weak references
@@ -41,11 +41,11 @@ The query only works for a single object.
 Path2GCRootsQuery.object.help = Specification for a single object for which paths to garbage collection roots should be found.\n\
 Do not use the class pattern unless the class just has a singleton instance.\n\
 Do not use the OQL query unless it returns a single object.
-Path2GCRootsQuery.excludes.help = Fields of certain classes which should be ignored when finding paths. \
+Path2GCRootsQuery.excludes.help = Fields of certain classes or entire classes which should be ignored when finding paths. \
 For example this allows paths through Weak or Soft Reference referents to be ignored.
 Path2GCRootsQuery.numberOfPaths.help = The number of different paths to be displayed.
 
-MultiplePath2GCRootsQuery.name = exclude custom field...
+MultiplePath2GCRootsQuery.name = exclude custom fields or classes...
 MultiplePath2GCRootsQuery.category = 4|Merge Shortest Paths to GC Roots
 MultiplePath2GCRootsQuery.menu.0.label = 1|with all references
 MultiplePath2GCRootsQuery.menu.1.label = 2|exclude weak references
@@ -57,7 +57,7 @@ MultiplePath2GCRootsQuery.menu.6.label = 7|exclude phantom/weak references
 MultiplePath2GCRootsQuery.menu.7.label = 8|exclude all phantom/weak/soft etc. references
 MultiplePath2GCRootsQuery.help = Find common paths from garbage collection roots to an object or set of objects.
 MultiplePath2GCRootsQuery.objects.help = Objects for which paths to garbage collection roots should be found.
-MultiplePath2GCRootsQuery.excludes.help = Fields of certain classes which should be ignored when finding paths. \
+MultiplePath2GCRootsQuery.excludes.help = Fields of certain classes or entire classes which should be ignored when finding paths. \
 For example this allows paths through Weak or Soft Reference referents to be ignored.
 MultiplePath2GCRootsQuery.groupBy.help = Whether to show:\n\
 merged paths from garbage collection roots to the objects\n\


### PR DESCRIPTION
Fixes #129

`java.lang.ref.Reference:referent` could have been used instead of all three sub-reference types, but this way it's easier to remove one or more in case one is not only looking for strong reference chains.