### PR TITLE
feat: Allow escaping $ in OQL commands by doing $$

### DIFF
--- a/plugins/org.eclipse.mat.report/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.report/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Export-Package: org.eclipse.mat,
  org.eclipse.mat.query.registry;x-friends:="org.eclipse.mat.ui,org.eclipse.mat.api,org.eclipse.mat.chart,org.eclipse.mat.chart.ui",
  org.eclipse.mat.query.results,
  org.eclipse.mat.report,
+ org.eclipse.mat.report.internal;x-friends:="org.eclipse.mat.tests",
  org.eclipse.mat.util
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.3.100",
  org.eclipse.core.resources;bundle-version="3.3.0"

--- a/plugins/org.eclipse.mat.report/src/org/eclipse/mat/report/internal/Parameters.java
+++ b/plugins/org.eclipse.mat.report/src/org/eclipse/mat/report/internal/Parameters.java
@@ -49,6 +49,14 @@ public abstract class Parameters
             if (p1 < 0)
                 return value;
 
+            // $${...} is an escape sequence that produces a literal ${...}
+            if (p1 > 0 && value.charAt(p1 - 1) == '$')
+            {
+                value = value.substring(0, p1 - 1) + value.substring(p1);
+                p0 = p1 + 1;
+                continue;
+            }
+
             int p2 = value.indexOf('}', p1);
             if (p2 < 0)
                 return value;

--- a/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/AllTests.java
+++ b/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/AllTests.java
@@ -47,7 +47,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 org.eclipse.mat.tests.collect.ExtractCollectionEntriesTest3.class, //
                 org.eclipse.mat.tests.collect.ExtractCollectionEntriesTest4.class, //
                 org.eclipse.mat.tests.ui.snapshot.panes.textPartitioning.TestClassNameExtractor.class,
-                org.eclipse.mat.tests.ui.snapshot.panes.textPartitioning.TestOQLPartitionScanner.class })
+                org.eclipse.mat.tests.ui.snapshot.panes.textPartitioning.TestOQLPartitionScanner.class, //
+                org.eclipse.mat.tests.report.ParametersExpandTest.class })
 public class AllTests
 {
 

--- a/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/report/ParametersExpandTest.java
+++ b/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/report/ParametersExpandTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.mat.tests.report;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.mat.report.internal.Parameters;
+import org.junit.Test;
+
+public class ParametersExpandTest
+{
+    private static Parameters params(Map<String, String> map)
+    {
+        return new Parameters.Deep(map);
+    }
+
+    @Test
+    public void testNoSubstitution()
+    {
+        assertEquals("hello world", params(Collections.emptyMap()).expand("hello world")); //$NON-NLS-1$//$NON-NLS-2$
+    }
+
+    @Test
+    public void testSimpleSubstitution()
+    {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("name", "world"); //$NON-NLS-1$//$NON-NLS-2$
+        assertEquals("hello world", params(map).expand("hello ${name}")); //$NON-NLS-1$//$NON-NLS-2$
+    }
+
+    @Test
+    public void testUnknownKeyBecomesEmpty()
+    {
+        assertEquals("hello ", params(Collections.emptyMap()).expand("hello ${missing}")); //$NON-NLS-1$//$NON-NLS-2$
+    }
+
+    @Test
+    public void testEscapeProducesLiteralBraces()
+    {
+        assertEquals("hello ${name}", params(Collections.emptyMap()).expand("hello $${name}")); //$NON-NLS-1$//$NON-NLS-2$
+    }
+
+    @Test
+    public void testEscapeIsNotSubstituted()
+    {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("name", "world"); //$NON-NLS-1$//$NON-NLS-2$
+        assertEquals("hello ${name}", params(map).expand("hello $${name}")); //$NON-NLS-1$//$NON-NLS-2$
+    }
+
+    @Test
+    public void testEscapeAndSubstitutionInSameString()
+    {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("p", "X"); //$NON-NLS-1$//$NON-NLS-2$
+        assertEquals("${p} X", params(map).expand("$${p} ${p}")); //$NON-NLS-1$//$NON-NLS-2$
+    }
+
+    @Test
+    public void testOQLVariableEscapePattern()
+    {
+        // Mirrors the real use case: an OQL subquery reference like ${adder}
+        // must survive Parameters.expand() when written as $${adder}
+        Map<String, String> map = new HashMap<String, String>();
+        String oql = "oql \"SELECT * FROM OBJECTS $${adder}.cells\""; //$NON-NLS-1$
+        String expected = "oql \"SELECT * FROM OBJECTS ${adder}.cells\""; //$NON-NLS-1$
+        assertEquals(expected, params(map).expand(oql));
+    }
+
+    @Test
+    public void testNullReturnsNull()
+    {
+        assertNull(params(Collections.emptyMap()).expand(null));
+    }
+
+    @Test
+    public void testUnclosedBraceIsLeftAlone()
+    {
+        assertEquals("${unclosed", params(Collections.emptyMap()).expand("${unclosed")); //$NON-NLS-1$//$NON-NLS-2$
+    }
+}

--- a/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/snapshot/OQLTest.java
+++ b/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/snapshot/OQLTest.java
@@ -36,11 +36,13 @@ import static org.junit.Assert.assertTrue;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.eclipse.mat.SnapshotException;
+import org.eclipse.mat.report.internal.Parameters;
 import org.eclipse.mat.collect.ArrayInt;
 import org.eclipse.mat.collect.IteratorInt;
 import org.eclipse.mat.query.ContextProvider;
@@ -1579,6 +1581,33 @@ public class OQLTest
         assertThat(irt.getRowCount(), greaterThan(0));
         assertThat(irt.getColumns().length, equalTo(3));
         checkGetOQL(irt);
+    }
+
+    /**
+     * Regression test for issue #143: OQL outer-variable references written as
+     * $${name} in report XML must survive Parameters.expand() as ${name} so the
+     * OQL parser can use them as outer-variable references in correlated sub-queries.
+     */
+    @Test
+    public void testParametersExpandEscapePreservesOQLEnvVar() throws SnapshotException
+    {
+        // In report XML the inner command is written with $${h} to protect the
+        // outer-variable reference from Parameters.expand().
+        String xmlInner = "(SELECT e.getKey() AS key, e.getValue() AS value FROM OBJECTS $${h}[0:-1] e)"; //$NON-NLS-1$
+
+        // Simulate Parameters.expand() with an empty parameter map (no report
+        // parameter named 'h'): $${h} must become ${h}, not empty string.
+        Parameters params = new Parameters.Deep(Collections.emptyMap());
+        String oqlInner = params.expand(xmlInner);
+        assertEquals("(SELECT e.getKey() AS key, e.getValue() AS value FROM OBJECTS ${h}[0:-1] e)", oqlInner); //$NON-NLS-1$
+
+        // Wrap in an outer query that binds 'h' and execute end-to-end against
+        // a real snapshot to confirm ${h} is correctly treated as an OQL outer-var.
+        String fullOql = "SELECT z.map AS Map, z.kv.key AS Key, z.kv.value AS Value " //$NON-NLS-1$
+                        + "FROM OBJECTS (SELECT h AS map, " + oqlInner + " AS kv FROM java.util.HashMap h) z " //$NON-NLS-1$
+                        + "WHERE (z.kv.key != null)"; //$NON-NLS-1$
+        IResultTable irt = (IResultTable) execute(fullOql);
+        assertThat(irt.getRowCount(), greaterThan(0));
     }
 
     @Test


### PR DESCRIPTION
fixes #143

Before
```
../org.eclipse.mat.product/target/products/org.eclipse.mat.ui.rcp.MemoryAnalyzer/macosx/cocoa/aarch64/MemoryAnalyzer.app/Contents/Eclipse/ParseHeapDump.sh \
    ~/Downloads/heapdump.hprof \
    "-command=oql \"SELECT adder.base AS base, (SELECT cell.value AS value FROM OBJECTS ${adder}.cells[0:-1] cell ) AS cells FROM java.util.concurrent.atomic.LongAdder adder \"" \
    org.eclipse.mat.api:query
```

<img width="700" height="331" alt="image" src="https://github.com/user-attachments/assets/07badc66-6b1a-41c8-a556-c2dc5ee13106" />



After -- note carefully the escaped `\$` to avoid the shell modifying the `$$`.

```
../org.eclipse.mat.product/target/products/org.eclipse.mat.ui.rcp.MemoryAnalyzer/macosx/cocoa/aarch64/MemoryAnalyzer.app/Contents/Eclipse/ParseHeapDump.sh \
    ~/Downloads/heapdump.hprof \
    "-command=oql \"SELECT adder.base AS base, (SELECT cell.value AS value FROM OBJECTS \$\${adder}.cells[0:-1] cell ) AS cells FROM java.util.concurrent.atomic.LongAdder adder \"" \
    org.eclipse.mat.api:query
```

<img width="442" height="427" alt="image" src="https://github.com/user-attachments/assets/fcda5bd7-abe3-4e75-b6e3-57517cce10b4" />