### PR TITLE
Add GitHub action workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,16 +1,25 @@
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
-name: OnPush
+name: CI
+
 on:
   push:
-    branches:
+    branches: ["master"]
   pull_request:
-    branches:
+    branches: ["master"]
   workflow_dispatch:
+
+permissions:
+  # need permission to write to checks in order for spotbugs to upload check info
+  checks: write
+  contents: read
 
 env:
   MAVEN_VERSION: 3.9.12
+
 jobs:
   build_and_test:
+    # only run from main repo (i.e. not forks)
+    if: github.repository == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,3 +50,12 @@ jobs:
           mvn --version
           mvn clean
           mvn install -Pskip-ui-tests
+          mvn spotbugs:spotbugs -Dspotbugs.xmlOutput=true -Dspotbugs.failOnError=false
+
+      - name: Upload spotbugs
+        # only run for PRs
+        if: github.event_name == 'pull_request'
+        uses: lcollins/spotbugs-github-action@v3.2.0
+        with:
+          path: '**/spotbugsXml.xml'
+


### PR DESCRIPTION
Rebased continuation of #55.

This filters to run for PRs and pushes to master branch.

Notes
- It **only** runs if the PR is originating from the main repo, so, not from forks, to simplify the concerns mentioned in #55.
- It does not yet build a snapshot to download, though I might work on that.
- Produces a CI run for us here that does not block merge on failure.
- Leaves existing Jenkins workflows untouched.
- Spotbugs is executed and uploaded but does not block the merge.

<img width="895" height="357" alt="image" src="https://github.com/user-attachments/assets/f80df90f-6275-4822-8c25-6e7803fc753f" />
