### PR TITLE
nit: more spotbugs fixes

### DIFF
--- a/plugins/org.eclipse.mat.api/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.mat.api/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Bundle-Activator: org.eclipse.mat.internal.MATPlugin
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy
 Eclipse-BuddyPolicy: registered
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Localization: plugin
 Bundle-Copyright: Copyright (c) 2008, 2022 SAP AG, IBM Corporation and others. 
  All rights reserved. This program and the accompanying materials 

--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/LeakHunterQuery.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/LeakHunterQuery.java
@@ -645,7 +645,7 @@ public class LeakHunterQuery implements IQuery
         boolean multipleItems = entries.size() > 1 && topItems > 1;
         PriorityQueue<Entry<Integer, Long>> pq = new PriorityQueue<Entry<Integer, Long>>(entries.size(),
                         (e1, e2) -> e2.getValue().compareTo(e1.getValue()));
-        pq.addAll(entries);
+        entries.forEach(e -> pq.add(Map.entry(e.getKey(), e.getValue())));
         int maxItems = Math.min(pq.size(), topItems);
         while (maxItems-- > 0 && pq.size() > 0)
         {

--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadInfoImpl.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/threads/ThreadInfoImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.eclipse.mat.SnapshotException;
 import org.eclipse.mat.collect.ArrayInt;
 import org.eclipse.mat.internal.Messages;
@@ -157,6 +158,7 @@ import org.eclipse.mat.util.IProgressListener;
         return null;
     }
 
+    @CheckForNull
     private static Boolean resolveIsDaemon(IObject thread)
     {
         try

--- a/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/util/ObjectTreeFactory.java
+++ b/plugins/org.eclipse.mat.api/src/org/eclipse/mat/inspections/util/ObjectTreeFactory.java
@@ -106,7 +106,7 @@ public final class ObjectTreeFactory
 
         public IResultTree build(ISnapshot snapshot)
         {
-            return new NodeResult(snapshot, root, base, false, incoming);
+            return new NodeResult(snapshot, root, base, incoming);
         }
     }
 
@@ -117,7 +117,6 @@ public final class ObjectTreeFactory
     private static class Node
     {
         int ownId;
-        String attributeName;
         List<Node> children;
         boolean isExpanded;
         boolean isSelected;
@@ -175,15 +174,13 @@ public final class ObjectTreeFactory
         private ISnapshot snapshot;
         private Node invisibleRoot;
         private long base;
-        private boolean decorateWithAttributeName;
         private Boolean incoming;
 
-        private NodeResult(ISnapshot snapshot, Node root, long base, boolean decorateWithAttributeName, Boolean incoming)
+        private NodeResult(ISnapshot snapshot, Node root, long base, Boolean incoming)
         {
             this.snapshot = snapshot;
             this.invisibleRoot = root;
             this.base = base;
-            this.decorateWithAttributeName = decorateWithAttributeName;
             this.incoming = incoming;
         }
 
@@ -195,20 +192,6 @@ public final class ObjectTreeFactory
         public Column[] getColumns()
         {
             Column classNameCol = new Column(Messages.Column_ClassName, String.class);
-            if (decorateWithAttributeName)
-                classNameCol.decorator(new IDecorator()
-                {
-                    public String prefix(Object row)
-                    {
-                        return ((Node) row).attributeName;
-                    }
-
-                    public String suffix(Object row)
-                    {
-                        return null;
-                    }
-                });
-
             if (base > 0)
                 return new Column[] { classNameCol, COL_HEAP, COL_RETAINED, col_percent() };
             else

--- a/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/CreateCollectionDump.java
+++ b/plugins/org.eclipse.mat.tests/src/org/eclipse/mat/tests/CreateCollectionDump.java
@@ -1042,19 +1042,15 @@ public class CreateCollectionDump
                     enumVals.put(Month.of(i), values[i]);
             }
             SimpleType<String> st[] = Collections.nCopies(COUNT, SimpleType.STRING).toArray(new SimpleType[COUNT]);
-            CompositeType ct1;
-            TabularType tt1;
             try
             {
                 // keys[], values[] is 1-offset, we need 0-offset
-                ct1 = new CompositeType("composite test", "a composite type", mapVals.keySet().toArray(new String[COUNT]), mapVals.values().toArray(new String[COUNT]), st);
-                tt1 = new TabularType("tabular test", "testing tabular types with strings", ct1, mapVals.keySet().toArray(new String[COUNT]));
+                CompositeType ct1 = new CompositeType("composite test", "a composite type", mapVals.keySet().toArray(new String[COUNT]), mapVals.values().toArray(new String[COUNT]), st);
+                new TabularType("tabular test", "testing tabular types with strings", ct1, mapVals.keySet().toArray(new String[COUNT]));
             }
             catch (OpenDataException e)
             {
                 e.printStackTrace();
-                ct1 = null;
-                tt1 = null;
             }
             Map<String,String>mapVals2 = new HashMap<String,String>(mapVals);
             // Arguments


### PR DESCRIPTION
Fix four spotbugs issues:
1) `Node.attributeName` was never written to, always stayed null -> remove the attributeName field, which means `decorateWithAttributeName` is never used (all class private), and the codepath can be cleaned up.

2) `LeakHunterQuery` reuses the Map.Entry object which might be reused -> reconstruct a new Map Entry.
    - the Map.entry() constructor requires Java9+

3) `resolveIsDaemon` returns Boolean, which might be auto-unboxed to `boolean` by caller and trigger a NPE -> Annotating @CheckForNulls ensures call site is validated to check that it is null before using.

4) Value stored to `tt1` which was never read -> Shuffle things around so scope is more natural/clear.