### PR TITLE
[Fix #190]: Ensure higher Javac for AtomicLongArray.compareAndExchange

### DIFF
--- a/testing/jcstress-tests/pom.xml
+++ b/testing/jcstress-tests/pom.xml
@@ -68,7 +68,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <!--
             Java source/target to use for compilation.
           -->
-        <javac.target>1.8</javac.target>
+        <javac.target>21</javac.target>
 
         <!--
             Name of the test Uber-JAR to generate.


### PR DESCRIPTION
Fixes #190 

I think the [latest consensus](https://github.com/eclipse-mat/mat/issues/174#issuecomment-4162600448) is Java 21 is the general target, so updated to that.